### PR TITLE
Update README.md to include yarn commmand

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 ## Available Scripts
 
 In the project directory, you can run:
+### `yarn`
+
+Automatically installs all the dependencies required by the project
 
 ### `yarn start`
 


### PR DESCRIPTION
On installing and running the app for the first time, directly running yarn start does not work and fails with a error saying that it is missing some dependencies like react-script, hence users first need to run `yarn`, once inside the directory